### PR TITLE
fixed cameras configuration

### DIFF
--- a/gazebo/cer/conf/gazebo_cer_depthCamera.ini
+++ b/gazebo/cer/conf/gazebo_cer_depthCamera.ini
@@ -2,7 +2,7 @@
 
 device RGBDSensorWrapper
 period 30
-name /${gazeboYarpPluginsRobotName}
+name /${gazeboYarpPluginsRobotName}/xtion
 
 [ROS]
 use_ROS	true

--- a/gazebo/cer/conf/gazebo_cer_depthCamera.ini
+++ b/gazebo/cer/conf/gazebo_cer_depthCamera.ini
@@ -2,7 +2,7 @@
 
 device RGBDSensorWrapper
 period 30
-name /${gazeboYarpPluginsRobotName}/xtion
+name /${gazeboYarpPluginsRobotName}/depthCamera
 
 [ROS]
 use_ROS	true

--- a/gazebo/cer/conf/gazebo_cer_multicamera.ini
+++ b/gazebo/cer/conf/gazebo_cer_multicamera.ini
@@ -1,6 +1,6 @@
 [include "gazebo_cer_robotname.ini"]
 
-device grabber
+device grabberDual
 subdevice gazebo_multicamera
 name /${gazeboYarpPluginsRobotName}/cam/cameras:o
 framerate 30

--- a/gazebo/cer/conf/gazebo_cer_xtion_camera_rgb.ini
+++ b/gazebo/cer/conf/gazebo_cer_xtion_camera_rgb.ini
@@ -2,6 +2,6 @@
 
 device grabber
 subdevice gazebo_camera
-name /${gazeboYarpPluginsRobotName}/cam/cameras:o
+name /${gazeboYarpPluginsRobotName}/xtionrgb/cameras:o
 framerate 30
 stamp 1

--- a/gazebo/cer/conf/gazebo_cer_xtion_camera_rgb.ini
+++ b/gazebo/cer/conf/gazebo_cer_xtion_camera_rgb.ini
@@ -2,6 +2,6 @@
 
 device grabber
 subdevice gazebo_camera
-name /${gazeboYarpPluginsRobotName}/xtionrgb/cameras:o
+name /${gazeboYarpPluginsRobotName}/depthCamera_rgb/camera:o
 framerate 30
 stamp 1


### PR DESCRIPTION
In this PR I updated the configuration files of cameras in order to fix following errors:
1) address conflict: the wrappers of the multicamera and xtion camera rgb open the port with the same name: Port /SIM_CER_ROBOT/cam/cameras:o active at tcp://10.240.11.23:10006/
2) use older version of device grabber: updated with GrabberDual
3) the RGBDSensorWrapper opened a port rpc called   SIM_CER_ROBOT/rpc: the name is not clear.

Now the following ports are available:
/SIM_CER_ROBOT/rgbImage:o  ==> stream of Leopard cameras
/SIM_CER_ROBOT/xtion/rgbImage:o  ==> stream of xtion rgb image
/SIM_CER_ROBOT/xtionrgb/cameras:o  ==> stream of xtion depth image
/SIM_CER_ROBOT/cam/cameras:o/rpc ==> awful name of rpc of Leopard cameras
/SIM_CER_ROBOT/xtion/rpc:i ==> rpc port of xtion

Moreover note that there is the following error:

> [ERROR]MUltiCamera: Unable to get the iFrameGrabberImage interface from the device

This error is not correct, because the view is done on the wrapper instead of on device; so I propose to open an issue to fix it.

Thanks to @barbalberto  for his help!
