### PR TITLE
Explicitly set the VELOCITY_CONTROL::velocityControlImplementationType parameter to ensure compatibility with gazebo-yarp-plugins 4

### DIFF
--- a/gazebo/cer/conf/gazebo_cer_head.ini
+++ b/gazebo/cer/conf/gazebo_cer_head.ini
@@ -38,6 +38,7 @@ stictionUp   0     0
 stictionDwn  0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_left_hand.ini
+++ b/gazebo/cer/conf/gazebo_cer_left_hand.ini
@@ -39,6 +39,7 @@ stictionUp   0     0     0     0
 stictionDwn  0     0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0  20.0 

--- a/gazebo/cer/conf/gazebo_cer_left_upper_arm.ini
+++ b/gazebo/cer/conf/gazebo_cer_left_upper_arm.ini
@@ -37,6 +37,7 @@ stictionUp   0     0    0     0     0
 stictionDwn  0     0    0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0 20.0  20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_left_wrist.ini
+++ b/gazebo/cer/conf/gazebo_cer_left_wrist.ini
@@ -36,6 +36,7 @@ stictionUp   0       0     0
 stictionDwn  0       0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_left_wrist_tripod.ini
+++ b/gazebo/cer/conf/gazebo_cer_left_wrist_tripod.ini
@@ -48,6 +48,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_mobile_base.ini
+++ b/gazebo/cer/conf/gazebo_cer_mobile_base.ini
@@ -37,6 +37,7 @@ stictionUp   0     0
 stictionDwn  0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           0.3   0.3

--- a/gazebo/cer/conf/gazebo_cer_right_hand.ini
+++ b/gazebo/cer/conf/gazebo_cer_right_hand.ini
@@ -39,6 +39,7 @@ stictionUp   0     0     0     0
 stictionDwn  0     0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0  20.0 

--- a/gazebo/cer/conf/gazebo_cer_right_upper_arm.ini
+++ b/gazebo/cer/conf/gazebo_cer_right_upper_arm.ini
@@ -37,6 +37,7 @@ stictionUp   0     0    0     0     0
 stictionDwn  0     0    0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0 20.0  20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_right_wrist.ini
+++ b/gazebo/cer/conf/gazebo_cer_right_wrist.ini
@@ -37,6 +37,7 @@ stictionUp   0       0     0
 stictionDwn  0       0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_right_wrist_tripod.ini
+++ b/gazebo/cer/conf/gazebo_cer_right_wrist_tripod.ini
@@ -48,6 +48,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/gazebo/cer/conf/gazebo_cer_torso.ini
+++ b/gazebo/cer/conf/gazebo_cer_torso.ini
@@ -42,6 +42,7 @@ stictionUp   0         0     0       0
 stictionDwn  0         0     0       0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            20.0  20.0  20.0   20.0

--- a/gazebo/cer/conf/gazebo_cer_torso_tripod.ini
+++ b/gazebo/cer/conf/gazebo_cer_torso_tripod.ini
@@ -48,6 +48,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_head.ini
+++ b/resources/conf/gazebo_cer_head.ini
@@ -38,6 +38,7 @@ stictionUp   0     0
 stictionDwn  0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0

--- a/resources/conf/gazebo_cer_left_hand.ini
+++ b/resources/conf/gazebo_cer_left_hand.ini
@@ -39,6 +39,7 @@ stictionUp   0     0     0     0
 stictionDwn  0     0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0  20.0 

--- a/resources/conf/gazebo_cer_left_upper_arm.ini
+++ b/resources/conf/gazebo_cer_left_upper_arm.ini
@@ -37,6 +37,7 @@ stictionUp   0     0    0     0     0
 stictionDwn  0     0    0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0 20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_left_wrist.ini
+++ b/resources/conf/gazebo_cer_left_wrist.ini
@@ -36,6 +36,7 @@ stictionUp   0       0     0
 stictionDwn  0       0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_left_wrist_tripod.ini
+++ b/resources/conf/gazebo_cer_left_wrist_tripod.ini
@@ -48,6 +48,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_mobile_base.ini
+++ b/resources/conf/gazebo_cer_mobile_base.ini
@@ -37,6 +37,7 @@ stictionUp   0     0
 stictionDwn  0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           0.3   0.3

--- a/resources/conf/gazebo_cer_right_hand.ini
+++ b/resources/conf/gazebo_cer_right_hand.ini
@@ -39,6 +39,7 @@ stictionUp   0     0     0     0
 stictionDwn  0     0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0  20.0 

--- a/resources/conf/gazebo_cer_right_upper_arm.ini
+++ b/resources/conf/gazebo_cer_right_upper_arm.ini
@@ -37,6 +37,7 @@ stictionUp   0     0    0     0     0
 stictionDwn  0     0    0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0 20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_right_wrist.ini
+++ b/resources/conf/gazebo_cer_right_wrist.ini
@@ -37,6 +37,7 @@ stictionUp   0       0     0
 stictionDwn  0       0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_right_wrist_tripod.ini
+++ b/resources/conf/gazebo_cer_right_wrist_tripod.ini
@@ -48,6 +48,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0

--- a/resources/conf/gazebo_cer_torso.ini
+++ b/resources/conf/gazebo_cer_torso.ini
@@ -42,6 +42,7 @@ stictionUp   0         0     0       0
 stictionDwn  0         0     0       0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp            20.0  20.0  20.0   20.0

--- a/resources/conf/gazebo_cer_torso_tripod.ini
+++ b/resources/conf/gazebo_cer_torso_tripod.ini
@@ -48,6 +48,7 @@ stictionUp   0     0     0
 stictionDwn  0     0     0
 
 [VELOCITY_CONTROL]
+velocityControlImplementationType direct_velocity_pid
 controlUnits  metric_units
 controlLaw    joint_pid_gazebo_v1
 kp           20.0  20.0  20.0


### PR DESCRIPTION
In https://github.com/robotology/gazebo-yarp-plugins/pull/514 (changelog entry: https://github.com/robotology/gazebo-yarp-plugins/blob/master/CHANGELOG.md#351---2020-10-05), the `VELOCITY_CONTROL::velocityControlImplementationType` parameter was added to the `gazebo_yarp_control` plugin to permit the users to switch between velocity control implemented between the `direct_velocity_pid` implementation (the default used until then) and the `integrator_and_position_pid` implementation (that is not a velocity-based PID, but rather an integrator in series with the classical position control).

The parameter was added as optional in gazebo-yarp-plugins 3.5.1, but to avoid confusion it will be make compulsory in gazebo-yarp-plugins 4 . To avoid creating runtime error in gazebo-yarp-plugins 4, this PR adds the parameter to the configuration files in this repo, using the default value `direct_velocity_pid`. However, mantainers may want to switch to use integrator_and_position_pid`  it if makes more sense in the future.

Related issues: https://github.com/robotology/gazebo-yarp-plugins/issues/577, https://github.com/robotology/gazebo-yarp-plugins/pull/578 .