### PR TITLE
Decimal places limit options for depthCamera

### DIFF
--- a/gazebo/cer/conf/gazebo_cer_depthcamera/gazebo_cer_depthcamera.ini
+++ b/gazebo/cer/conf/gazebo_cer_depthcamera/gazebo_cer_depthcamera.ini
@@ -6,3 +6,6 @@ focalLengthX 570.3422241210938
 focalLengthY 570.3422241210938
 tangentialPointX 0.0
 tangentialPointY 0.0
+
+[QUANT_PARAM]
+depth_quant 2


### PR DESCRIPTION
Added a set of parameters related to depth data alteration (decimal
places limitation)

This parameter is linked to the [PR #608](https://github.com/robotology/gazebo-yarp-plugins/pull/608) for the [gazebo-yarp-plugins](https://github.com/robotology/gazebo-yarp-plugins) repo.