### PR TITLE
Changed topic name of lidar for consistency

### DIFF
--- a/catkin_ws/src/cer_rviz/rviz/cer.rviz
+++ b/catkin_ws/src/cer_rviz/rviz/cer.rviz
@@ -429,7 +429,7 @@ Visualization Manager:
       Size (Pixels): 3
       Size (m): 0.10000000149011612
       Style: Flat Squares
-      Topic: /double_lidar
+      Topic: /laser
       Unreliable: false
       Use Fixed Frame: true
       Use rainbow: true

--- a/colcon_ws/src/cer_rviz2/rviz2/cer.rviz
+++ b/colcon_ws/src/cer_rviz2/rviz2/cer.rviz
@@ -273,7 +273,7 @@ Visualization Manager:
         Durability Policy: Volatile
         History Policy: Keep Last
         Reliability Policy: Reliable
-        Value: /double_lidar
+        Value: /laser
       Use Fixed Frame: true
       Use rainbow: true
       Value: true

--- a/gazebo/cer/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros.xml
+++ b/gazebo/cer/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros">
     <param name="period"> 0.01 </param>
     <param name="node_name">    /rangefinder_ros_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/gazebo/cer/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros2.xml
+++ b/gazebo/cer/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros2.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros2">
     <param name="period"> 0.01 </param>
     <param name="node_name">    rangefinder_ros2_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/gazebo/cer/conf/gazebo_cer_lasersensor/gazebo_cer_lasersensor360_nws_ros.xml
+++ b/gazebo/cer/conf/gazebo_cer_lasersensor/gazebo_cer_lasersensor360_nws_ros.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros">
     <param name="period"> 0.01 </param>
     <param name="node_name">    /rangefinder_ros_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/gazebo/cer/conf/gazebo_cer_lasersensor/gazebo_cer_lasersensor360_nws_ros2.xml
+++ b/gazebo/cer/conf/gazebo_cer_lasersensor/gazebo_cer_lasersensor360_nws_ros2.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros2">
     <param name="period"> 0.01 </param>
     <param name="node_name">    rangefinder_ros2_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/gazebo/cer_no_collisions_20m/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros.xml
+++ b/gazebo/cer_no_collisions_20m/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros">
     <param name="period"> 0.01 </param>
     <param name="node_name">    /rangefinder_ros_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/gazebo/cer_no_collisions_20m/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros2.xml
+++ b/gazebo/cer_no_collisions_20m/conf/gazebo_cer_doublelaser/gazebo_cer_doublelaser_nws_ros2.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros2">
     <param name="period"> 0.01 </param>
     <param name="node_name">    rangefinder_ros2_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">

--- a/gazebo/cer_no_collisions_20m/conf/gazebo_cer_lasersensor/gazebo_cer_lasersensor360_nws_ros.xml
+++ b/gazebo/cer_no_collisions_20m/conf/gazebo_cer_lasersensor/gazebo_cer_lasersensor360_nws_ros.xml
@@ -4,7 +4,7 @@
 <device xmlns:xi="http://www.w3.org/2001/XInclude" name="lidarWrapR" type="rangefinder2D_nws_ros">
     <param name="period"> 0.01 </param>
     <param name="node_name">    /rangefinder_ros_node    </param>
-    <param name="topic_name">   /double_lidar   </param>
+    <param name="topic_name">   /laser   </param>
     <param name="frame_id">    mobile_base_double_lidar   </param>
     <action phase="startup" level="5" type="attach">
         <paramlist name="networks">


### PR DESCRIPTION
Renamed the topic from /double_lidar to /laser to be consistent with the same topic name that the robot has.

[Robot conf](https://github.com/randaz81/robots-configuration/tree/R1SN003_ros2/R1SN003/wrappers/rpLidar)
